### PR TITLE
Error handling in CG serialization

### DIFF
--- a/jcg_dynamic_testadapter/src/main/resources/DynamicCG.cpp
+++ b/jcg_dynamic_testadapter/src/main/resources/DynamicCG.cpp
@@ -35,24 +35,30 @@ static map<Callsite, unordered_set<jmethodID>> cg;
 
 static void getMethodNameSig(jmethodID mid, char** nameSig) {
     jclass cls;
-    jvmti->GetMethodDeclaringClass(mid, &cls);
+    int err = jvmti->GetMethodDeclaringClass(mid, &cls);
 
-    char* cname;
-    char* generic;
-    jvmti->GetClassSignature(cls, &cname, &generic);
+    if(err == JVMTI_ERROR_NONE){
+        char* cname;
+        char* generic;
+        jvmti->GetClassSignature(cls, &cname, &generic);
 
-    jvmti->Deallocate((unsigned char*) generic);
+        jvmti->Deallocate((unsigned char*) generic);
 
-    char* mname;
-    char* sig;
-    jvmti->GetMethodName(mid, &mname, &sig, &generic);
+        char* mname;
+        char* sig;
+        jvmti->GetMethodName(mid, &mname, &sig, &generic);
 
-    asprintf(nameSig, "%s:%s%s", (cname == NULL ? "" : cname), (mname == NULL ? "" : mname), (sig == NULL ? "" : sig));
+        asprintf(nameSig, "%s:%s%s", (cname == NULL ? "" : cname), (mname == NULL ? "" : mname), (sig == NULL ? "" : sig));
 
-    jvmti->Deallocate((unsigned char*) cname);
-    jvmti->Deallocate((unsigned char*) mname);
-    jvmti->Deallocate((unsigned char*) sig);
-    jvmti->Deallocate((unsigned char*) generic);
+        jvmti->Deallocate((unsigned char*) cname);
+        jvmti->Deallocate((unsigned char*) mname);
+        jvmti->Deallocate((unsigned char*) sig);
+        jvmti->Deallocate((unsigned char*) generic);
+    } else {
+        asprintf(nameSig, "<FAILED>");
+    }
+
+    
 }
 
 void JNICALL MethodEntry(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jmethodID method) {

--- a/jcg_dynamic_testadapter/src/main/scala/DynamicJCGAdapter.scala
+++ b/jcg_dynamic_testadapter/src/main/scala/DynamicJCGAdapter.scala
@@ -69,10 +69,14 @@ object DynamicJCGAdapter extends JCGTestAdapter {
             val endMessage = "End of Callgraph"
             var caller = in.readLine()
 
-            while(caller != endMessage){
 
-                println("Got Msg: " + caller)
-            	
+            var cnt = 0L
+            println("Reading messages: " + caller)
+
+            while(caller != endMessage){
+                
+                if(cnt % 1000 == 0) println("Number of messages from agent: " + cnt)
+
             	val parsedCaller = if(caller == "TopLevel"){
 			        None     	
             	} else{
@@ -101,7 +105,8 @@ object DynamicJCGAdapter extends JCGTestAdapter {
                     targets(pcLn) += parsedCallee
                 }
 
-                caller = in.readLine()	
+                caller = in.readLine()
+                cnt += 1L
             }
 
             System.nanoTime()

--- a/jcg_dynamic_testadapter/src/main/scala/DynamicJCGAdapter.scala
+++ b/jcg_dynamic_testadapter/src/main/scala/DynamicJCGAdapter.scala
@@ -69,13 +69,7 @@ object DynamicJCGAdapter extends JCGTestAdapter {
             val endMessage = "End of Callgraph"
             var caller = in.readLine()
 
-
-            var cnt = 0L
-            println("Reading messages: " + caller)
-
             while(caller != endMessage){
-                
-                if(cnt % 1000 == 0) println("Number of messages from agent: " + cnt)
 
             	val parsedCaller = if(caller == "TopLevel"){
 			        None     	
@@ -106,7 +100,6 @@ object DynamicJCGAdapter extends JCGTestAdapter {
                 }
 
                 caller = in.readLine()
-                cnt += 1L
             }
 
             System.nanoTime()

--- a/jcg_dynamic_testadapter/src/main/scala/DynamicJCGAdapter.scala
+++ b/jcg_dynamic_testadapter/src/main/scala/DynamicJCGAdapter.scala
@@ -70,6 +70,8 @@ object DynamicJCGAdapter extends JCGTestAdapter {
             var caller = in.readLine()
 
             while(caller != endMessage){
+
+                println("Got Msg: " + caller)
             	
             	val parsedCaller = if(caller == "TopLevel"){
 			        None     	


### PR DESCRIPTION
Up until now, we did not check the status code returned by `jvmti->GetMethodDeclaringClass`, however [it may in fact be unsuccessful](https://docs.oracle.com/javase/8/docs/platform/jvmti/jvmti.html#GetMethodDeclaringClass). This PR adds a check for the return code to indicate success before using the resulting class `cls` for further queries.

I checked this on a small sample input set for batik and results were identical to before.

There is also some changes to what i think are undesired whitespaces in `DynamicJCGAdapter.scala`, let me know if you think otherwise and i'll revert those changes.