### PR TITLE
Various fixes to some JCG Adapters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,8 @@ lazy val jcg_data_format = project.settings(
     assembly / aggregate := false,
     libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.2",
     libraryDependencies += "io.get-coursier" %% "coursier" % "2.1.8",
-    libraryDependencies += "io.get-coursier" %% "coursier-cache" % "2.1.8"
+    libraryDependencies += "io.get-coursier" %% "coursier-cache" % "2.1.8",
+    libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.3"
 )
 
 lazy val jcg_testcases = project.settings(
@@ -56,6 +57,7 @@ lazy val jcg_wala_testadapter = project.settings(
     libraryDependencies += "com.ibm.wala" % "com.ibm.wala.util" % "1.5.7",
     libraryDependencies += "com.ibm.wala" % "com.ibm.wala.shrike" % "1.5.7",
     libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.2",
+    libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.3",
     assembly / aggregate := false,
     publishArtifact := false
 ).dependsOn(jcg_testadapter_commons)

--- a/jcg_evaluation/src/main/scala/FingerprintExtractor.scala
+++ b/jcg_evaluation/src/main/scala/FingerprintExtractor.scala
@@ -40,8 +40,7 @@ trait FingerprintExtractor {
                 val output = new BufferedWriter(new FileWriter(adapterDir.getAbsolutePath + "/" + testDir + ".json"))
 
                 val future = Future {
-                    // execute adapter
-                    try {
+                    val elapsed = try {
                         adapter.serializeCG(
                             cgAlgorithm,
                             s"${inputDir.getAbsolutePath}/$testDir",
@@ -52,11 +51,19 @@ trait FingerprintExtractor {
                             if (config.debug) {
                                 println(e.getMessage)
                             }
+                            -1
                     } finally {
                         output.close()
                     }
 
-                    // try reading and matching resulting call graph
+                    // write the timing information (just like in Evaluation.runAnalyses())
+                    val seconds = elapsed / 1000000000d
+                    val timingFile = new File(adapterDir, s"$testDir.timing.txt")
+                    val pw = new PrintWriter(timingFile)
+                    pw.write(s"$seconds sec.")
+                    pw.close()
+                    println(s"analysis for $testDir took $seconds sec.")
+
                     ow.synchronized {
                         System.gc()
 

--- a/jcg_evaluation/src/main/scala/JavaFingerprintExtractor.scala
+++ b/jcg_evaluation/src/main/scala/JavaFingerprintExtractor.scala
@@ -54,7 +54,7 @@ object JavaFingerprintExtractor extends FingerprintExtractor {
                 println(s"performing test case: ${projectSpec.name}")
 
                 val future = Future {
-                    try {
+                    val elapsed = try {
                         adapter.serializeCG(
                             cgAlgorithm,
                             projectSpec.target(projectsDir).getCanonicalPath,
@@ -71,9 +71,19 @@ object JavaFingerprintExtractor extends FingerprintExtractor {
                             if (config.debug) {
                                 println(e.printStackTrace())
                             }
+                            -1
                     } finally {
                         output.close()
                     }
+                    
+                    // write the timing information (just like in Evaluation.runAnalyses())
+                    val seconds = elapsed / 1000000000d
+                    val timingFile = new File(outDir, "timings.txt")
+                    val pw = new PrintWriter(timingFile)
+                    pw.write(s"$seconds sec.")
+                    pw.close()
+                    println(s"analysis for ${projectSpec.name} took $seconds sec.")
+
                     ow.synchronized {
                         System.gc()
 

--- a/jcg_soot_testadapter/src/main/scala/SootJCGAdapter.scala
+++ b/jcg_soot_testadapter/src/main/scala/SootJCGAdapter.scala
@@ -29,6 +29,7 @@ object SootJCGAdapter extends JavaTestAdapter {
         output:         Writer,
         adapterOptions: AdapterOptions
     ): Long = {
+        G.reset()
         val mainClass = adapterOptions.getString("mainClass")
         val classPath = adapterOptions.getStringArray("classPath")
         val JDKPath = adapterOptions.getString("JDKPath")


### PR DESCRIPTION
### Soot adapter
Changed to also reset the graph before generating the callgraph. The reset is useful not only after running a Soot analysis, but also before to ensure that there is no residual class in the soot classpath.

### Timing output
was present for the Evaluation subproject, but not the FingerprintExtractor

### WALA adapter
For some input projects we would always run into memory issues when the adapter code tried to stringify the whole callgraph, which is fixed using a stream during serialization of the callgraph.

From the Logfile:
```
java.lang.OutOfMemoryError
	at java.base/java.lang.AbstractStringBuilder.hugeCapacity(AbstractStringBuilder.java:214)
	at java.base/java.lang.AbstractStringBuilder.newCapacity(AbstractStringBuilder.java:206)
	at java.base/java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:173)
	at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:686)
	at java.base/java.lang.StringBuffer.append(StringBuffer.java:414)
	at java.base/java.io.StringWriter.write(StringWriter.java:99)
	at com.fasterxml.jackson.core.json.WriterBasedJsonGenerator._flushBuffer(WriterBasedJsonGenerator.java:2034)
	at com.fasterxml.jackson.core.json.WriterBasedJsonGenerator.flush(WriterBasedJsonGenerator.java:973)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:3128)
	at com.fasterxml.jackson.core.base.GeneratorBase.writeTree(GeneratorBase.java:404)
	at play.api.libs.json.jackson.JsValueSerializer.serialize(JacksonJson.scala:85)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$2(JacksonJson.scala:105)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$2$adapted(JacksonJson.scala:103)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at play.api.libs.json.jackson.JsValueSerializer.serialize(JacksonJson.scala:103)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$1(JacksonJson.scala:96)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$1$adapted(JacksonJson.scala:95)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at play.api.libs.json.jackson.JsValueSerializer.serialize(JacksonJson.scala:95)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$2(JacksonJson.scala:105)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$2$adapted(JacksonJson.scala:103)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at play.api.libs.json.jackson.JsValueSerializer.serialize(JacksonJson.scala:103)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$1(JacksonJson.scala:96)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$1$adapted(JacksonJson.scala:95)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at play.api.libs.json.jackson.JsValueSerializer.serialize(JacksonJson.scala:95)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$2(JacksonJson.scala:105)
	at play.api.libs.json.jackson.JsValueSerializer.$anonfun$serialize$2$adapted(JacksonJson.scala:103)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at play.api.libs.json.jackson.JsValueSerializer.serialize(JacksonJson.scala:103)
	at play.api.libs.json.jackson.JsValueSerializer.serialize(JacksonJson.scala:64)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1514)
	at com.fasterxml.jackson.databind.ObjectWriter.writeValue(ObjectWriter.java:1006)
	at play.api.libs.json.jackson.JacksonJson$.$anonfun$prettyPrint$1(JacksonJson.scala:322)
	at play.api.libs.json.jackson.JacksonJson$.withStringWriter(JacksonJson.scala:291)
	at play.api.libs.json.jackson.JacksonJson$.prettyPrint(JacksonJson.scala:316)
	at play.api.libs.json.StaticBinding$.prettyPrint(StaticBinding.scala:26)
	at play.api.libs.json.Json$.prettyPrint(Json.scala:189)
	at WalaBasedJCGAdapter.serializeCG(WalaJCGAdapter.scala:162)
	at Evaluation$.$anonfun$runAnalyses$5(Evaluation.scala:165)
	at Evaluation$.$anonfun$runAnalyses$5$adapted(Evaluation.scala:132)
	at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1328)
	at Evaluation$.$anonfun$runAnalyses$4(Evaluation.scala:132)
	at Evaluation$.$anonfun$runAnalyses$4$adapted(Evaluation.scala:130)
	at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1328)
	at Evaluation$.$anonfun$runAnalyses$2(Evaluation.scala:130)
	at Evaluation$.$anonfun$runAnalyses$2$adapted(Evaluation.scala:129)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at Evaluation$.runAnalyses(Evaluation.scala:129)
	at Evaluation$.main(Evaluation.scala:51)
	at Evaluation.main(Evaluation.scala)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at sbt.Run.invokeMain(Run.scala:143)
	at sbt.Run.execute$1(Run.scala:93)
	at sbt.Run.$anonfun$runWithLoader$5(Run.scala:120)
	at sbt.Run$.executeSuccess(Run.scala:186)
	at sbt.Run.runWithLoader(Run.scala:120)
	at sbt.Defaults$.$anonfun$bgRunMainTask$7(Defaults.scala:1949)
	at sbt.Defaults$.$anonfun$termWrapper$2(Defaults.scala:1920)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.util.Try$.apply(Try.scala:213)
	at sbt.internal.BackgroundThreadPool$BackgroundRunnable.run(DefaultBackgroundJobService.scala:369)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

